### PR TITLE
Migrate Google Maps markers to AdvancedMarkerElement

### DIFF
--- a/src/components/GoogleMapsNavigation.tsx
+++ b/src/components/GoogleMapsNavigation.tsx
@@ -98,15 +98,24 @@ const GoogleMapsNavigation: React.FC<GoogleMapsNavigationProps> = ({
     if (directionsService && directionsRenderer && origin) {
       calculateRoute();
     } else if (map && !origin) {
-      // Show just the destination marker if no origin
-      new window.google.maps.Marker({
-        position: destination,
-        map: map,
-        title: destination.address,
-        icon: {
-          url: "https://maps.google.com/mapfiles/ms/icons/red-dot.png",
-        },
-      });
+      // Show just the destination marker if no origin using AdvancedMarkerElement
+      if (window.google.maps.marker?.AdvancedMarkerElement) {
+        new window.google.maps.marker.AdvancedMarkerElement({
+          position: destination,
+          map: map,
+          title: destination.address,
+        });
+      } else {
+        // Fallback to old marker for backwards compatibility
+        new window.google.maps.Marker({
+          position: destination,
+          map: map,
+          title: destination.address,
+          icon: {
+            url: "https://maps.google.com/mapfiles/ms/icons/red-dot.png",
+          },
+        });
+      }
     }
   }, [directionsService, directionsRenderer, origin, destination]);
 

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -168,7 +168,7 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
       const loader = new Loader({
         apiKey: import.meta.env.VITE_GOOGLE_MAPS_API_KEY || "",
         version: "weekly",
-        libraries: ["places", "geometry"],
+        libraries: ["places", "geometry", "marker"], // Include marker library for AdvancedMarkerElement
       });
 
       const google = await loader.load();

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -305,40 +305,72 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
         });
       }
 
-      // Add drag start listener for visual feedback
-      newMarker.addListener("dragstart", () => {
-        newMarker.setIcon({
-          url: "data:image/svg+xml;charset=UTF-8,%3csvg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%23059669' stroke='%23ffffff' stroke-width='2'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
-          scaledSize: new google.maps.Size(36, 36),
-          anchor: new google.maps.Point(18, 36),
+      // Add event listeners that work with both marker types
+      if (newMarker instanceof google.maps.marker.AdvancedMarkerElement) {
+        // For AdvancedMarkerElement
+        newMarker.addListener("dragstart", () => {
+          // Visual feedback for advanced marker
+          if (newMarker.content instanceof HTMLElement) {
+            newMarker.content.style.transform = "scale(1.1)";
+            newMarker.content.style.filter = "brightness(1.2)";
+          }
         });
-      });
 
-      // Add drag end listener with address update
-      newMarker.addListener(
-        "dragend",
-        async (event: google.maps.MapMouseEvent) => {
+        newMarker.addListener("dragend", async (event: any) => {
           if (event.latLng) {
-            // Reset marker icon
-            newMarker.setIcon({
-              url: "data:image/svg+xml;charset=UTF-8,%3csvg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%2316a34a' stroke='%23ffffff' stroke-width='1'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
-              scaledSize: new google.maps.Size(32, 32),
-              anchor: new google.maps.Point(16, 32),
-            });
-
+            // Reset visual feedback
+            if (newMarker.content instanceof HTMLElement) {
+              newMarker.content.style.transform = "scale(1)";
+              newMarker.content.style.filter = "brightness(1)";
+            }
             // Update address
             await handleMapClick(event.latLng);
           }
-        },
-      );
+        });
 
-      // Add bounce animation on click
-      newMarker.addListener("click", () => {
-        newMarker.setAnimation(google.maps.Animation.BOUNCE);
-        setTimeout(() => {
-          newMarker.setAnimation(null);
-        }, 700);
-      });
+        newMarker.addListener("click", () => {
+          // Simple bounce effect for advanced marker
+          if (newMarker.content instanceof HTMLElement) {
+            newMarker.content.style.animation = "bounce 0.7s ease-in-out";
+            setTimeout(() => {
+              newMarker.content.style.animation = "";
+            }, 700);
+          }
+        });
+      } else if (newMarker instanceof google.maps.Marker) {
+        // For legacy Marker
+        newMarker.addListener("dragstart", () => {
+          newMarker.setIcon({
+            url: "data:image/svg+xml;charset=UTF-8,%3csvg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%23059669' stroke='%23ffffff' stroke-width='2'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
+            scaledSize: new google.maps.Size(36, 36),
+            anchor: new google.maps.Point(18, 36),
+          });
+        });
+
+        newMarker.addListener(
+          "dragend",
+          async (event: google.maps.MapMouseEvent) => {
+            if (event.latLng) {
+              // Reset marker icon
+              newMarker.setIcon({
+                url: "data:image/svg+xml;charset=UTF-8,%3csvg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%2316a34a' stroke='%23ffffff' stroke-width='1'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
+                scaledSize: new google.maps.Size(32, 32),
+                anchor: new google.maps.Point(16, 32),
+              });
+
+              // Update address
+              await handleMapClick(event.latLng);
+            }
+          },
+        );
+
+        newMarker.addListener("click", () => {
+          newMarker.setAnimation(google.maps.Animation.BOUNCE);
+          setTimeout(() => {
+            newMarker.setAnimation(null);
+          }, 700);
+        });
+      }
 
       setMarker(newMarker);
     },

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -100,7 +100,9 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
     useState<google.maps.places.PlacesService | null>(null);
   const [autocompleteService, setAutocompleteService] =
     useState<google.maps.places.AutocompleteService | null>(null);
-  const [marker, setMarker] = useState<google.maps.Marker | null>(null);
+  const [marker, setMarker] = useState<
+    google.maps.marker.AdvancedMarkerElement | google.maps.Marker | null
+  >(null);
   const [isMapLoading, setIsMapLoading] = useState(true);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -178,18 +180,36 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
         }
       });
 
-      // Add default center marker for India
-      const defaultMarker = new google.maps.Marker({
-        position: defaultCenter,
-        map: map,
-        title: "Click anywhere on the map to select location",
-        icon: {
-          url: "data:image/svg+xml;charset=UTF-8,%3csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%23dc2626'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
-          scaledSize: new google.maps.Size(24, 24),
-          anchor: new google.maps.Point(12, 24),
-        },
-        animation: google.maps.Animation.BOUNCE,
-      });
+      // Add default center marker for India using AdvancedMarkerElement
+      let defaultMarker;
+      if (google.maps.marker?.AdvancedMarkerElement) {
+        const markerContent = document.createElement("div");
+        markerContent.innerHTML = `
+          <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+            <path d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='#dc2626'/>
+            <circle cx='12' cy='10' r='3' fill='white'/>
+          </svg>
+        `;
+        defaultMarker = new google.maps.marker.AdvancedMarkerElement({
+          position: defaultCenter,
+          map: map,
+          title: "Click anywhere on the map to select location",
+          content: markerContent,
+        });
+      } else {
+        // Fallback to old marker
+        defaultMarker = new google.maps.Marker({
+          position: defaultCenter,
+          map: map,
+          title: "Click anywhere on the map to select location",
+          icon: {
+            url: "data:image/svg+xml;charset=UTF-8,%3csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%23dc2626'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
+            scaledSize: new google.maps.Size(24, 24),
+            anchor: new google.maps.Point(12, 24),
+          },
+          animation: google.maps.Animation.BOUNCE,
+        });
+      }
 
       // Remove default marker after 3 seconds
       setTimeout(() => {
@@ -250,19 +270,40 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
         marker.setMap(null);
       }
 
-      // Add new marker with enhanced visual feedback
-      const newMarker = new google.maps.Marker({
-        position: coordinates,
-        map: mapInstance,
-        draggable: true,
-        animation: google.maps.Animation.DROP,
-        title: "Drag to adjust location or click map to move pin",
-        icon: {
-          url: "data:image/svg+xml;charset=UTF-8,%3csvg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%2316a34a' stroke='%23ffffff' stroke-width='1'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
-          scaledSize: new google.maps.Size(32, 32),
-          anchor: new google.maps.Point(16, 32),
-        },
-      });
+      // Add new marker with enhanced visual feedback using AdvancedMarkerElement
+      let newMarker;
+      if (google.maps.marker?.AdvancedMarkerElement) {
+        const markerContent = document.createElement("div");
+        markerContent.innerHTML = `
+          <svg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+            <path d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='#16a34a' stroke='#ffffff' stroke-width='1'/>
+            <circle cx='12' cy='10' r='3' fill='white'/>
+          </svg>
+        `;
+        markerContent.style.cursor = "pointer";
+
+        newMarker = new google.maps.marker.AdvancedMarkerElement({
+          position: coordinates,
+          map: mapInstance,
+          title: "Drag to adjust location or click map to move pin",
+          content: markerContent,
+          gmpDraggable: true,
+        });
+      } else {
+        // Fallback to old marker
+        newMarker = new google.maps.Marker({
+          position: coordinates,
+          map: mapInstance,
+          draggable: true,
+          animation: google.maps.Animation.DROP,
+          title: "Drag to adjust location or click map to move pin",
+          icon: {
+            url: "data:image/svg+xml;charset=UTF-8,%3csvg width='32' height='32' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z' fill='%2316a34a' stroke='%23ffffff' stroke-width='1'/%3e%3ccircle cx='12' cy='10' r='3' fill='white'/%3e%3c/svg%3e",
+            scaledSize: new google.maps.Size(32, 32),
+            anchor: new google.maps.Point(16, 32),
+          },
+        });
+      }
 
       // Add drag start listener for visual feedback
       newMarker.addListener("dragstart", () => {

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -534,14 +534,14 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
         console.log("🌐 Trying browser location fallback...");
         const browserLocation = await getBrowserLocation();
         if (browserLocation) {
-          setSelectedLocation(ipLocation);
-          setSearchQuery(ipLocation.address);
-          updateMapLocation(ipLocation.coordinates);
-          autoFillAddressFields(ipLocation.address);
+          setSelectedLocation(browserLocation);
+          setSearchQuery(browserLocation.address);
+          updateMapLocation(browserLocation.coordinates);
+          autoFillAddressFields(browserLocation.address);
           return;
         }
-      } catch (ipError) {
-        console.warn("IP location fallback failed:", ipError);
+      } catch (locationError) {
+        console.warn("Browser location fallback failed:", locationError);
       }
 
       // Ultimate fallback - major Indian cities based on common usage

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -17,6 +17,32 @@ import {
 import { locationService, Coordinates } from "@/services/locationService";
 import { Loader } from "@googlemaps/js-api-loader";
 
+// Add CSS for bounce animation
+const bounceAnimation = `
+  @keyframes bounce {
+    0%, 20%, 50%, 80%, 100% {
+      transform: translateY(0);
+    }
+    40% {
+      transform: translateY(-10px);
+    }
+    60% {
+      transform: translateY(-5px);
+    }
+  }
+`;
+
+// Add style element to document head
+if (
+  typeof document !== "undefined" &&
+  !document.querySelector("#bounce-animation-styles")
+) {
+  const style = document.createElement("style");
+  style.id = "bounce-animation-styles";
+  style.textContent = bounceAnimation;
+  document.head.appendChild(style);
+}
+
 interface AddressData {
   flatNo: string;
   street: string;

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -531,9 +531,9 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
 
       // Enhanced fallback - try to get approximate location from IP
       try {
-        console.log("🌐 Trying IP-based location fallback...");
-        const ipLocation = await getIPBasedLocation();
-        if (ipLocation) {
+        console.log("🌐 Trying browser location fallback...");
+        const browserLocation = await getBrowserLocation();
+        if (browserLocation) {
           setSelectedLocation(ipLocation);
           setSearchQuery(ipLocation.address);
           updateMapLocation(ipLocation.coordinates);

--- a/src/components/ZomatoAddAddressPage.tsx
+++ b/src/components/ZomatoAddAddressPage.tsx
@@ -291,9 +291,13 @@ const ZomatoAddAddressPage: React.FC<ZomatoAddAddressPageProps> = ({
       mapInstance.setCenter(coordinates);
       mapInstance.setZoom(16);
 
-      // Remove existing marker
+      // Remove existing marker (works for both AdvancedMarkerElement and legacy Marker)
       if (marker) {
-        marker.setMap(null);
+        if (marker instanceof google.maps.marker.AdvancedMarkerElement) {
+          marker.map = null;
+        } else if (marker instanceof google.maps.Marker) {
+          marker.setMap(null);
+        }
       }
 
       // Add new marker with enhanced visual feedback using AdvancedMarkerElement

--- a/src/components/ZomatoAddressSelector.tsx
+++ b/src/components/ZomatoAddressSelector.tsx
@@ -69,12 +69,7 @@ const ZomatoAddressSelector: React.FC<ZomatoAddressSelectorProps> = ({
       // Try to load from backend first using apiClient
       const userId = currentUser._id || currentUser.id || currentUser.phone;
 
-      // Set user ID header for apiClient
-      const response = await apiClient.request<any[]>("/addresses", {
-        headers: {
-          "user-id": userId,
-        },
-      });
+      const response = await apiClient.getAddresses(userId);
 
       if (response.data) {
         // Transform backend format to frontend format

--- a/src/components/ZomatoAddressSelector.tsx
+++ b/src/components/ZomatoAddressSelector.tsx
@@ -66,18 +66,17 @@ const ZomatoAddressSelector: React.FC<ZomatoAddressSelectorProps> = ({
 
     setLoading(true);
     try {
-      // Try to load from backend first
+      // Try to load from backend first using apiClient
       const userId = currentUser._id || currentUser.id || currentUser.phone;
-      const response = await fetch("/api/addresses", {
+
+      // Set user ID header for apiClient
+      const response = await apiClient.request<any[]>("/addresses", {
         headers: {
           "user-id": userId,
-          "Content-Type": "application/json",
         },
       });
 
-      if (response.ok) {
-        const result = await response.json();
-        if (result.data) {
+      if (response.data) {
           // Transform backend format to frontend format
           const transformedAddresses = result.data.map((addr: any) => ({
             id: addr._id,

--- a/src/components/ZomatoAddressSelector.tsx
+++ b/src/components/ZomatoAddressSelector.tsx
@@ -77,22 +77,21 @@ const ZomatoAddressSelector: React.FC<ZomatoAddressSelectorProps> = ({
       });
 
       if (response.data) {
-          // Transform backend format to frontend format
-          const transformedAddresses = result.data.map((addr: any) => ({
-            id: addr._id,
-            type: addr.address_type || "other",
-            label: addr.title,
-            flatNo: addr.full_address.split(",")[0] || "",
-            fullAddress: addr.full_address,
-            landmark: addr.landmark || "",
-            phone: addr.contact_phone || currentUser.phone,
-            coordinates: addr.coordinates,
-            createdAt: addr.created_at,
-          }));
-          setSavedAddresses(transformedAddresses);
-          setLoading(false);
-          return;
-        }
+        // Transform backend format to frontend format
+        const transformedAddresses = response.data.map((addr: any) => ({
+          id: addr._id,
+          type: addr.address_type || "other",
+          label: addr.title,
+          flatNo: addr.full_address.split(",")[0] || "",
+          fullAddress: addr.full_address,
+          landmark: addr.landmark || "",
+          phone: addr.contact_phone || currentUser.phone,
+          coordinates: addr.coordinates,
+          createdAt: addr.created_at,
+        }));
+        setSavedAddresses(transformedAddresses);
+        setLoading(false);
+        return;
       }
 
       // Fallback to localStorage if backend fails

--- a/src/components/ZomatoAddressSelector.tsx
+++ b/src/components/ZomatoAddressSelector.tsx
@@ -19,6 +19,7 @@ import {
   Edit,
   Trash2,
 } from "lucide-react";
+import { apiClient } from "@/lib/apiClient";
 
 interface SavedAddress {
   id: string;

--- a/src/components/ZomatoAddressSelector.tsx
+++ b/src/components/ZomatoAddressSelector.tsx
@@ -120,15 +120,14 @@ const ZomatoAddressSelector: React.FC<ZomatoAddressSelectorProps> = ({
 
     try {
       const userId = currentUser._id || currentUser.id || currentUser.phone;
-      const response = await fetch(`/api/addresses/${addressId}`, {
+      const response = await apiClient.request(`/addresses/${addressId}`, {
         method: "DELETE",
         headers: {
           "user-id": userId,
-          "Content-Type": "application/json",
         },
       });
 
-      if (response.ok) {
+      if (response.data) {
         // Remove from state
         setSavedAddresses((prev) =>
           prev.filter((addr) => addr.id !== addressId),

--- a/src/components/ZomatoAddressSelector.tsx
+++ b/src/components/ZomatoAddressSelector.tsx
@@ -115,12 +115,7 @@ const ZomatoAddressSelector: React.FC<ZomatoAddressSelectorProps> = ({
 
     try {
       const userId = currentUser._id || currentUser.id || currentUser.phone;
-      const response = await apiClient.request(`/addresses/${addressId}`, {
-        method: "DELETE",
-        headers: {
-          "user-id": userId,
-        },
-      });
+      const response = await apiClient.deleteAddress(userId, addressId);
 
       if (response.data) {
         // Remove from state

--- a/src/config/production-env.ts
+++ b/src/config/production-env.ts
@@ -12,6 +12,13 @@ export const getProductionApiUrl = (): string => {
   const isProduction =
     !hostname.includes("localhost") && !hostname.includes("127.0.0.1");
 
+  console.log("🔍 API URL Detection:", {
+    hostname,
+    isProduction,
+    currentUrl: window.location.href,
+    apiUrl: isProduction ? PRODUCTION_API_URL : "http://localhost:3001/api",
+  });
+
   if (isProduction) {
     console.log(
       "🚀 Production environment detected, using:",

--- a/src/config/production-env.ts
+++ b/src/config/production-env.ts
@@ -3,8 +3,18 @@
  * Handles proper API URL detection for production deployment
  */
 
-// Define the correct production API URL
-export const PRODUCTION_API_URL = "https://cleancarepro-95it.onrender.com/api";
+// Define the correct production API URL based on current frontend URL
+export const PRODUCTION_API_URL = (() => {
+  const hostname = window.location.hostname;
+
+  // If we're on cleancarepro-1-p2oc.onrender.com, use cleancarepro-95it.onrender.com for API
+  if (hostname.includes("cleancarepro-1-p2oc.onrender.com")) {
+    return "https://cleancarepro-95it.onrender.com/api";
+  }
+
+  // Default fallback
+  return "https://cleancarepro-95it.onrender.com/api";
+})();
 
 export const getProductionApiUrl = (): string => {
   // Check if we're in production based on hostname

--- a/src/config/production-env.ts
+++ b/src/config/production-env.ts
@@ -3,18 +3,8 @@
  * Handles proper API URL detection for production deployment
  */
 
-// Define the correct production API URL based on current frontend URL
-export const PRODUCTION_API_URL = (() => {
-  const hostname = window.location.hostname;
-
-  // If we're on cleancarepro-1-p2oc.onrender.com, use cleancarepro-95it.onrender.com for API
-  if (hostname.includes("cleancarepro-1-p2oc.onrender.com")) {
-    return "https://cleancarepro-95it.onrender.com/api";
-  }
-
-  // Default fallback
-  return "https://cleancarepro-95it.onrender.com/api";
-})();
+// Define the correct production API URL - always point to the backend
+export const PRODUCTION_API_URL = "https://cleancarepro-95it.onrender.com/api";
 
 export const getProductionApiUrl = (): string => {
   // Check if we're in production based on hostname

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -467,6 +467,69 @@ class EnhancedApiClient {
     });
   }
 
+  // Address endpoints
+  async getAddresses(userId: string): Promise<ApiResponse<any[]>> {
+    return this.request("/addresses", {
+      headers: {
+        "user-id": userId,
+      },
+    });
+  }
+
+  async createAddress(
+    userId: string,
+    addressData: any,
+  ): Promise<ApiResponse<any>> {
+    return this.request("/addresses", {
+      method: "POST",
+      headers: {
+        "user-id": userId,
+      },
+      body: addressData,
+    });
+  }
+
+  async updateAddress(
+    userId: string,
+    addressId: string,
+    addressData: any,
+  ): Promise<ApiResponse<any>> {
+    return this.request(`/addresses/${encodeURIComponent(addressId)}`, {
+      method: "PUT",
+      headers: {
+        "user-id": userId,
+      },
+      body: addressData,
+    });
+  }
+
+  async deleteAddress(
+    userId: string,
+    addressId: string,
+  ): Promise<ApiResponse<any>> {
+    return this.request(`/addresses/${encodeURIComponent(addressId)}`, {
+      method: "DELETE",
+      headers: {
+        "user-id": userId,
+      },
+    });
+  }
+
+  async setDefaultAddress(
+    userId: string,
+    addressId: string,
+  ): Promise<ApiResponse<any>> {
+    return this.request(
+      `/addresses/${encodeURIComponent(addressId)}/set-default`,
+      {
+        method: "PATCH",
+        headers: {
+          "user-id": userId,
+        },
+      },
+    );
+  }
+
   // Clear all pending requests (useful for component unmount)
   clearPendingRequests(): void {
     this.requestQueue.clear();

--- a/src/types/google-maps.d.ts
+++ b/src/types/google-maps.d.ts
@@ -11,6 +11,13 @@ declare global {
         LatLng: any;
         Size: any;
         Point: any;
+        Animation: {
+          BOUNCE: any;
+          DROP: any;
+        };
+        marker: {
+          AdvancedMarkerElement: any;
+        };
         places: {
           Autocomplete: any;
           AutocompleteService: any;

--- a/src/utils/modernGoogleMaps.ts
+++ b/src/utils/modernGoogleMaps.ts
@@ -373,7 +373,7 @@ const injectMarkerStyles = () => {
     .modern-custom-marker {
       animation: markerDrop 0.3s ease-out;
     }
-    
+
     @keyframes markerDrop {
       0% {
         transform: translateY(-30px) scale(0.8);
@@ -384,7 +384,7 @@ const injectMarkerStyles = () => {
         opacity: 1;
       }
     }
-    
+
     .modern-custom-marker:hover {
       z-index: 1000;
     }


### PR DESCRIPTION
Updates Google Maps implementation to use the new AdvancedMarkerElement API with fallback to legacy Marker for backwards compatibility.

Changes made:
- Added "marker" library to Google Maps loader configuration
- Replaced legacy google.maps.Marker with google.maps.marker.AdvancedMarkerElement in GoogleMapsNavigation component
- Updated ZomatoAddAddressPage to use AdvancedMarkerElement for both default and user-placed markers
- Added proper event handling for both marker types (AdvancedMarkerElement and legacy Marker)
- Implemented fallback logic to use legacy Marker when AdvancedMarkerElement is not available
- Updated marker state type to support both marker implementations
- Added bounce animation CSS for AdvancedMarkerElement markers
- Replaced IP-based geolocation with browser geolocation API
- Added address management endpoints to apiClient
- Updated ZomatoAddressSelector to use apiClient instead of direct fetch calls
- Enhanced production environment detection with additional logging
- Updated TypeScript definitions for Google Maps API

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/756f3f78573246d9ba20d09fce116be3/quantum-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>756f3f78573246d9ba20d09fce116be3</projectId>-->
<!--<branchName>quantum-den</branchName>-->