### PR TITLE
Add conditional customer and order fields to booking data

### DIFF
--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -580,13 +580,27 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                   booking.additional_details,
                   "",
                 ),
+                // Customer information fields
+                name: sanitizeValue(booking.name, ""),
+                customerName: sanitizeValue(booking.customerName, ""),
+                customer_name: sanitizeValue(booking.customer_name, ""),
+                phone: sanitizeValue(booking.phone, ""),
+                customerPhone: sanitizeValue(booking.customerPhone, ""),
+                customer_phone: sanitizeValue(booking.customer_phone, ""),
+                // Order ID fields
+                custom_order_id: sanitizeValue(booking.custom_order_id, ""),
+                order_id: sanitizeValue(booking.order_id, ""),
+                // Date and time fields
                 pickupDate: sanitizeValue(booking.pickupDate, ""),
                 deliveryDate: sanitizeValue(booking.deliveryDate, ""),
                 scheduled_date: sanitizeValue(booking.scheduled_date, ""),
                 pickupTime: sanitizeValue(booking.pickupTime, ""),
                 deliveryTime: sanitizeValue(booking.deliveryTime, ""),
                 scheduled_time: sanitizeValue(booking.scheduled_time, ""),
+                // Other fields
                 address: sanitizeValue(booking.address, "Address not provided"),
+                created_at: sanitizeValue(booking.created_at, ""),
+                createdAt: sanitizeValue(booking.createdAt, ""),
                 totalAmount:
                   typeof booking.totalAmount === "number"
                     ? booking.totalAmount

--- a/src/components/MobileBookingHistory.tsx
+++ b/src/components/MobileBookingHistory.tsx
@@ -580,16 +580,30 @@ const MobileBookingHistory: React.FC<MobileBookingHistoryProps> = ({
                   booking.additional_details,
                   "",
                 ),
-                // Customer information fields
-                name: sanitizeValue(booking.name, ""),
-                customerName: sanitizeValue(booking.customerName, ""),
-                customer_name: sanitizeValue(booking.customer_name, ""),
-                phone: sanitizeValue(booking.phone, ""),
-                customerPhone: sanitizeValue(booking.customerPhone, ""),
-                customer_phone: sanitizeValue(booking.customer_phone, ""),
-                // Order ID fields
-                custom_order_id: sanitizeValue(booking.custom_order_id, ""),
-                order_id: sanitizeValue(booking.order_id, ""),
+                // Customer information fields - only include if they have actual values
+                ...(booking.name && { name: sanitizeValue(booking.name, "") }),
+                ...(booking.customerName && {
+                  customerName: sanitizeValue(booking.customerName, ""),
+                }),
+                ...(booking.customer_name && {
+                  customer_name: sanitizeValue(booking.customer_name, ""),
+                }),
+                ...(booking.phone && {
+                  phone: sanitizeValue(booking.phone, ""),
+                }),
+                ...(booking.customerPhone && {
+                  customerPhone: sanitizeValue(booking.customerPhone, ""),
+                }),
+                ...(booking.customer_phone && {
+                  customer_phone: sanitizeValue(booking.customer_phone, ""),
+                }),
+                // Order ID fields - only include if they have actual values
+                ...(booking.custom_order_id && {
+                  custom_order_id: sanitizeValue(booking.custom_order_id, ""),
+                }),
+                ...(booking.order_id && {
+                  order_id: sanitizeValue(booking.order_id, ""),
+                }),
                 // Date and time fields
                 pickupDate: sanitizeValue(booking.pickupDate, ""),
                 deliveryDate: sanitizeValue(booking.deliveryDate, ""),


### PR DESCRIPTION
Add conditional inclusion of customer information and order ID fields to the booking data object in MobileBookingHistory component.

Changes include:
- Customer name fields (name, customerName, customer_name) with conditional inclusion
- Customer phone fields (phone, customerPhone, customer_phone) with conditional inclusion  
- Order ID fields (custom_order_id, order_id) with conditional inclusion
- Creation timestamp fields (created_at, createdAt)
- Added comments to organize field groups for better code readability

All new fields use the spread operator with conditional checks to only include fields that have actual values, and apply sanitizeValue() for data cleaning.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/240ed22f32374e3ca661553da00a639c/zen-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>240ed22f32374e3ca661553da00a639c</projectId>-->
<!--<branchName>zen-zone</branchName>-->