### PR TITLE
Fix touch interactions on iPhone Safari for cart buttons

### DIFF
--- a/src/components/LaundryCart.tsx
+++ b/src/components/LaundryCart.tsx
@@ -905,7 +905,10 @@ Confirm this booking?`;
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div
+      className="min-h-screen bg-gray-50"
+      style={{ pointerEvents: "auto", touchAction: "pan-y" }}
+    >
       {/* Header */}
       <div className="bg-white shadow-sm px-3 sm:px-4 py-4 flex items-center sticky top-0 z-10 safe-area-top">
         <div className="flex items-center gap-2 sm:gap-4">
@@ -1262,7 +1265,10 @@ Confirm this booking?`;
       </div>
 
       {/* Fixed Bottom Button */}
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-2 safe-area-bottom">
+      <div
+        className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-2 safe-area-bottom"
+        style={{ pointerEvents: "auto", zIndex: 50 }}
+      >
         <div className="space-y-2">
           {/* Validation Errors */}
           {validationErrors.length > 0 && (
@@ -1288,6 +1294,7 @@ Confirm this booking?`;
                 );
               }
             }}
+            style={{ pointerEvents: "auto", touchAction: "manipulation" }}
             disabled={cartItems.length === 0 || isProcessingCheckout}
             className="w-full bg-green-600 hover:bg-green-700 text-white py-2.5 rounded-lg text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >

--- a/src/components/LaundryCart.tsx
+++ b/src/components/LaundryCart.tsx
@@ -967,6 +967,10 @@ Confirm this booking?`;
                     size="sm"
                     onClick={() => updateQuantity(service!.id, -1)}
                     className="h-5 w-5 p-0 text-xs"
+                    style={{
+                      pointerEvents: "auto",
+                      touchAction: "manipulation",
+                    }}
                   >
                     <Minus className="h-2 w-2" />
                   </Button>
@@ -978,6 +982,10 @@ Confirm this booking?`;
                     size="sm"
                     onClick={() => updateQuantity(service!.id, 1)}
                     className="h-5 w-5 p-0 text-xs"
+                    style={{
+                      pointerEvents: "auto",
+                      touchAction: "manipulation",
+                    }}
                   >
                     <Plus className="h-2 w-2" />
                   </Button>
@@ -992,6 +1000,10 @@ Confirm this booking?`;
                     size="sm"
                     onClick={() => removeItem(service!.id)}
                     className="h-5 w-5 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
+                    style={{
+                      pointerEvents: "auto",
+                      touchAction: "manipulation",
+                    }}
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>
@@ -1316,34 +1328,42 @@ Confirm this booking?`;
       </div>
 
       {/* Zomato Address Selector */}
-      <ZomatoAddressSelector
-        isOpen={showZomatoAddressSelector}
-        onClose={() => setShowZomatoAddressSelector(false)}
-        onSelectAddress={handleAddressSelect}
-        onAddNewAddress={() => {
-          setEditingAddress(null);
-          setShowZomatoAddressSelector(false);
-          setShowZomatoAddAddressPage(true);
-        }}
-        onEditAddress={handleEditAddress}
-        currentUser={currentUser}
-        selectedAddressId={selectedSavedAddress?.id}
-      />
+      <div
+        style={{ pointerEvents: showZomatoAddressSelector ? "auto" : "none" }}
+      >
+        <ZomatoAddressSelector
+          isOpen={showZomatoAddressSelector}
+          onClose={() => setShowZomatoAddressSelector(false)}
+          onSelectAddress={handleAddressSelect}
+          onAddNewAddress={() => {
+            setEditingAddress(null);
+            setShowZomatoAddressSelector(false);
+            setShowZomatoAddAddressPage(true);
+          }}
+          onEditAddress={handleEditAddress}
+          currentUser={currentUser}
+          selectedAddressId={selectedSavedAddress?.id}
+        />
+      </div>
 
       {/* Zomato Add Address Page */}
-      <ZomatoAddAddressPage
-        isOpen={showZomatoAddAddressPage}
-        onClose={() => {
-          setShowZomatoAddAddressPage(false);
-          setEditingAddress(null);
-        }}
-        onSave={(address) => {
-          handleNewAddressSave(address);
-          setEditingAddress(null);
-        }}
-        currentUser={currentUser}
-        editingAddress={editingAddress}
-      />
+      <div
+        style={{ pointerEvents: showZomatoAddAddressPage ? "auto" : "none" }}
+      >
+        <ZomatoAddAddressPage
+          isOpen={showZomatoAddAddressPage}
+          onClose={() => {
+            setShowZomatoAddAddressPage(false);
+            setEditingAddress(null);
+          }}
+          onSave={(address) => {
+            handleNewAddressSave(address);
+            setEditingAddress(null);
+          }}
+          currentUser={currentUser}
+          editingAddress={editingAddress}
+        />
+      </div>
 
       {/* Saved Addresses Modal (fallback) */}
       <SavedAddressesModal

--- a/src/components/ZomatoStyleCart.tsx
+++ b/src/components/ZomatoStyleCart.tsx
@@ -323,7 +323,10 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div
+      className="min-h-screen bg-gray-50"
+      style={{ pointerEvents: "auto", touchAction: "pan-y" }}
+    >
       {/* Header - Zomato Style */}
       <div className="bg-white shadow-sm px-4 py-4 sticky top-0 z-10 safe-area-top">
         <div className="flex items-center gap-4">
@@ -637,11 +640,15 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
       )}
 
       {/* Fixed Bottom Payment Button - Zomato Style */}
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t px-4 py-4 safe-area-bottom">
+      <div
+        className="fixed bottom-0 left-0 right-0 bg-white border-t px-4 py-4 safe-area-bottom"
+        style={{ pointerEvents: "auto", zIndex: 50 }}
+      >
         <Button
           onClick={handleProceedToCheckout}
           disabled={cartItems.length === 0 || isProcessingCheckout}
           className="w-full bg-green-600 hover:bg-green-700 text-white py-4 rounded-lg font-semibold text-base disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          style={{ pointerEvents: "auto", touchAction: "manipulation" }}
         >
           {isProcessingCheckout ? (
             <>

--- a/src/components/ZomatoStyleCart.tsx
+++ b/src/components/ZomatoStyleCart.tsx
@@ -395,6 +395,10 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
                           size="sm"
                           onClick={() => updateQuantity(service!.id, -1)}
                           className="h-8 w-8 p-0 rounded-md border-green-600 text-green-600 hover:bg-green-50"
+                          style={{
+                            pointerEvents: "auto",
+                            touchAction: "manipulation",
+                          }}
                         >
                           <Minus className="h-4 w-4" />
                         </Button>
@@ -406,6 +410,10 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
                           size="sm"
                           onClick={() => updateQuantity(service!.id, 1)}
                           className="h-8 w-8 p-0 rounded-md border-green-600 text-green-600 hover:bg-green-50"
+                          style={{
+                            pointerEvents: "auto",
+                            touchAction: "manipulation",
+                          }}
                         >
                           <Plus className="h-4 w-4" />
                         </Button>
@@ -473,6 +481,7 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
                   disabled={!couponCode.trim()}
                   className="border-green-600 text-green-600 hover:bg-green-50"
                   type="button"
+                  style={{ pointerEvents: "auto", touchAction: "manipulation" }}
                 >
                   Apply
                 </Button>

--- a/src/styles/mobile-fixes.css
+++ b/src/styles/mobile-fixes.css
@@ -191,6 +191,59 @@ select {
   appearance: none;
 }
 
+/* iPhone-specific touch and pointer fixes */
+@supports (-webkit-touch-callout: none) {
+  /* iPhone Safari specific fixes */
+  * {
+    -webkit-tap-highlight-color: transparent;
+    -webkit-touch-callout: none;
+  }
+
+  /* Ensure all clickable elements work on iPhone */
+  button,
+  [role="button"],
+  .clickable,
+  input[type="button"],
+  input[type="submit"] {
+    cursor: pointer;
+    pointer-events: auto !important;
+    touch-action: manipulation !important;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* Fix for modal overlays blocking touches */
+  .modal-overlay {
+    pointer-events: auto !important;
+    touch-action: none !important;
+  }
+
+  /* Fix for fixed positioned elements */
+  .fixed {
+    transform: translate3d(0, 0, 0);
+    -webkit-transform: translate3d(0, 0, 0);
+  }
+
+  /* Ensure cart page elements are touchable */
+  .cart-container {
+    pointer-events: auto !important;
+    touch-action: pan-y !important;
+  }
+
+  .cart-button {
+    pointer-events: auto !important;
+    touch-action: manipulation !important;
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  /* Fix for overlapping elements */
+  .z-index-overlay {
+    isolation: isolate;
+  }
+}
+
 /* Prevent horizontal scroll */
 .mobile-container {
   overflow-x: hidden;


### PR DESCRIPTION
Add explicit pointer-events and touch-action styles to fix touch interaction issues on iPhone Safari.

Changes made:
- Added pointerEvents: "auto" and touchAction styles to cart container divs
- Applied touch-action: "manipulation" to quantity buttons (plus/minus/remove)
- Added pointer-events and z-index styles to fixed bottom button containers
- Wrapped modal components in divs with conditional pointer-events
- Added iPhone-specific CSS fixes in mobile-fixes.css including:
  - Webkit tap highlight and touch callout disabled
  - Explicit pointer-events and touch-action for buttons
  - Transform3d for fixed positioned elements
  - Minimum touch target sizes for cart buttons

These changes ensure cart functionality works properly on iPhone Safari where touch events were previously being blocked.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4a45832c51a043edaec044df18720a4b/vortex-forge)

👀 [Preview Link](https://4a45832c51a043edaec044df18720a4b-vortex-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4a45832c51a043edaec044df18720a4b</projectId>-->
<!--<branchName>vortex-forge</branchName>-->